### PR TITLE
Fixing default base_topic to misensor based on implementation

### DIFF
--- a/config.ini.dist
+++ b/config.ini.dist
@@ -50,7 +50,7 @@
 
 # The MQTT base topic to publish all Mi Flora sensor data topics under.
 # Default depends on the configured reporting_method
-#base_topic = miflora                   # Default for: mqtt-json, mqtt-smarthome
+#base_topic = misensor                  # Default for: mqtt-json, mqtt-smarthome
 #base_topic = homie                     # Default for: mqtt-homie
 #base_topic = homeassistant             # Default for: homeassistant-mqtt
 #base_topic = v1/devices/me/telemetry   # Default for: thingsboard-json


### PR DESCRIPTION
Hey, thanks for your great work - I have started using this branch and I very much like it.
However I would like propose update of config.ini.dist:

In config.ini.dist there is the following information:

> #The MQTT base topic to publish all Mi Flora sensor data topics under.
#Default depends on the configured reporting_method
#base_topic = miflora                   # Default for: mqtt-json, mqtt-smarthome
#base_topic = homie                     # Default for: mqtt-homie
#base_topic = homeassistant             # Default for: homeassistant-mqtt
#base_topic = v1/devices/me/telemetry   # Default for: thingsboard-json
#base_topic =                           # Default for: wirenboard-mqtt<

So as log as I use mqtt-json the default toppic should be miflora.

While the default toppic is no longer **miflora** but **misensor** - what makes total sense cause we no longer use only miflora sensors - also it was already implemented in miflora-mqtt-daemon.py:

>if reporting_mode == 'mqtt-homie':
    default_base_topic = 'homie'
elif reporting_mode == 'homeassistant-mqtt':
    default_base_topic = 'homeassistant'
elif reporting_mode == 'thingsboard-json':
    default_base_topic = 'v1/devices/me/telemetry'
elif reporting_mode == 'wirenboard-mqtt':
    default_base_topic = ''
else:
    default_base_topic = 'misensor'<

Hope you dont mind my changes