### PR TITLE
add additional MACs and add expiration for sensor state to home assistant discovery

### DIFF
--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -143,7 +143,7 @@ def init_sensors(sensor_type, sensors):
     sensor_type_name = sensor_type_to_name(sensor_type)
     if  sensor_type == sensor_type_miflora:
         config_section = sensor_type_miflora
-        mac_regexp = "C4:7C:8D:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}"
+        mac_regexp = "(C4:7C:8D|80:EA:CA):[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}"
     elif sensor_type == sensor_type_mitempbt:
         config_section = sensor_type_mitempbt
         mac_regexp = "(4C:65:A8|58:2D:34):[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}"

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -478,6 +478,7 @@ elif reporting_mode == 'homeassistant-mqtt':
         for sensor, params in miflora_parameters.items():
             payload = dict(base_payload.items())
             payload['unit_of_measurement'] = params['unit']
+            payload['expire_after'] = 28000
             payload['value_template'] = "{{ value_json.%s }}" % (sensor, )
             payload['name'] = "{} {}".format(flora_name, sensor.title())
             if 'device_class' in params:
@@ -491,6 +492,7 @@ elif reporting_mode == 'homeassistant-mqtt':
         for sensor, params in mitempbt_parameters.items():
             payload = dict(base_payload.items())
             payload['unit_of_measurement'] = params['unit']
+            payload['expire_after'] = 28000
             payload['value_template'] = "{{ value_json.%s }}" % (sensor, )
             payload['name'] = "{} {}".format(mitempbt_name, sensor.title())
             if 'device_class' in params:


### PR DESCRIPTION
This adds additional MACs used for newer MiFlora devices. i also added a expiration timeout of 8 hours to the home assistant mqtt data to cover when a sensor dies.